### PR TITLE
Fix ref for docker metadata step

### DIFF
--- a/.github/actions/docker/build/action.yml
+++ b/.github/actions/docker/build/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: ./.github/actions/docker/metadata
+      uses: descope/.github/.github/actions/docker/metadata@main
       with:
         images: |
           ${{inputs.image-name}}


### PR DESCRIPTION
## Related Issues
Fix bug due to https://github.com/descope/etc/issues/3430


## Description
Change ref to metadata action from relative path to github referene.

