### PR TITLE
fix(ci) - bump buildx setup to latest

### DIFF
--- a/.github/actions/docker/build/action.yml
+++ b/.github/actions/docker/build/action.yml
@@ -35,7 +35,7 @@ runs:
 
     - uses: docker/setup-buildx-action@v3 # Maybe it will work, or maybe it will not.
       with:
-        version: v0.20.0
+        version: latest
 
     - name: Build and push Docker image
       uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0


### PR DESCRIPTION
## Description

Trying fix that was mentioned here https://github.com/docker/build-push-action/issues/1345

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
