### PR TITLE
Add hello-descope sample Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "descope",
+  "owner": {
+    "name": "Descope",
+    "email": "dev@descope.com"
+  },
+  "plugins": [
+    {
+      "name": "hello-descope",
+      "source": "./plugins/hello-descope",
+      "description": "Sample plugin that greets you on session start",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/plugins/hello-descope/.claude-plugin/plugin.json
+++ b/plugins/hello-descope/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "hello-descope",
+  "displayName": "Hello Descope",
+  "version": "0.1.0",
+  "description": "Sample Descope Claude Code plugin — prints a greeting on session start",
+  "author": {
+    "name": "Descope"
+  },
+  "hooks": "./hooks/hooks.json"
+}

--- a/plugins/hello-descope/README.md
+++ b/plugins/hello-descope/README.md
@@ -1,0 +1,10 @@
+# hello-descope
+
+Sample Claude Code plugin for the Descope org. Prints "Hello from Descope" on session start — a template for building real org plugins on top of.
+
+## Install
+
+```
+/plugin marketplace add descope/.github
+/plugin install hello-descope@descope
+```

--- a/plugins/hello-descope/hooks/hooks.json
+++ b/plugins/hello-descope/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Hello from Descope'"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Related Issues

N/A

## Related PRs

N/A

## Description

This PR adds a sample Claude Code plugin for the Descope organization. The `hello-descope` plugin demonstrates the basic structure and configuration needed to build plugins for Claude Code, including:

- Plugin marketplace configuration (`.claude-plugin/marketplace.json`)
- Plugin metadata and hook definitions (`plugins/hello-descope/.claude-plugin/plugin.json`)
- Hook implementation that executes a command on session start (`plugins/hello-descope/hooks/hooks.json`)
- Installation instructions and documentation (`plugins/hello-descope/README.md`)

This serves as a template for building real organization plugins on top of.

## Must

- [x] Documentation (README with installation instructions included)
- [ ] Tests (N/A - sample/template plugin)

https://claude.ai/code/session_01AZveuCVH8FD1RQHxfWhkDw